### PR TITLE
Support to edit the stack name different of the service name

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -27,10 +27,13 @@ export default class StackOutputPlugin {
   }
 
   get stackName () {
-    return util.format('%s-%s',
-      this.serverless.service.getServiceName(),
-      this.serverless.getProvider('aws').getStage()
-    )
+    if (this.serverless.service.custom.output.stackName === undefined)
+      return util.format('%s-%s',
+        this.serverless.service.getServiceName(),
+        this.serverless.getProvider('aws').getStage()
+      )
+    else       
+      return this.serverless.service.custom.output.stackName
   }
 
   private hasConfig (key: string) {


### PR DESCRIPTION
The following error "Serverless: Cannot process Stack Output: Stack with <serviceName>-<stage> does not exist!" had been throwing because the predicted stackName was just a concatenated <serviceName>-<stage>. This issue occurs when the stackName is different of the serviceName. My help was to support a new one attribute called 'stackName' into the custom.output variable, and is optional as you can see.