### PR TITLE
bugfix : aync await in process function

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -136,8 +136,8 @@ export default class StackOutputPlugin {
     assert(this.options && !this.options.noDeploy, 'Skipping deployment with --noDeploy flag')
   }
 
-  private process () {
-    Promise.resolve()
+  private async process () {
+    await Promise.resolve()
     .then(
       () => this.validate()
     ).then(


### PR DESCRIPTION
Output was not saved to file when serverelss node process finished before writing the file.

This could happen when there was no changes in the stack
```Service files not changed. Skipping deployment...```