### PR TITLE
User serverless' getStackName() api

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -27,10 +27,7 @@ export default class StackOutputPlugin {
   }
 
   get stackName () {
-    return util.format('%s-%s',
-      this.serverless.service.getServiceName(),
-      this.serverless.getProvider('aws').getStage()
-    )
+    return this.serverless.getProvider('aws').naming.getStackName()
   }
 
   private hasConfig (key: string) {

--- a/vendor/serverless.d.ts
+++ b/vendor/serverless.d.ts
@@ -15,6 +15,10 @@ declare namespace Serverless {
       getStage: () => string
 
       request: (service: string, method: string, data: {}, stage: string, region: string) => Promise<any>
+
+      naming: {
+        getStackName(): string
+      }
     }
   }
 }


### PR DESCRIPTION
Hi, thanks for your work on this plugin

This PR makes use of serverless's api for a custom stack name, which was [implemented back in v1.28 or so.](https://github.com/serverless/serverless/pull/4951)

Let me know if you have questions, cheers

Fixes #15